### PR TITLE
Make sure, the parameter "port" is always treated as a number.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-socket-tcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "This Cordova plugin provides JavaScript API, that allows you to communicate with server through TCP protocol. Currently we support these platforms: iOS, Android, WP8.",
   "cordova": {
     "platforms": [

--- a/src/ios/SocketsForCordova/Classes/SocketPlugin.m
+++ b/src/ios/SocketsForCordova/Classes/SocketPlugin.m
@@ -26,7 +26,7 @@
     
     NSString *socketKey = [command.arguments objectAtIndex:0];
     NSString *host = [command.arguments objectAtIndex:1];
-    NSNumber *port = [command.arguments objectAtIndex:2];
+    NSNumber *port = [NSNumber numberWithInteger:[[command.arguments objectAtIndex:2] integerValue]];
 
     NSLog(@"[NATIVE] OPEN socket for port: %@", port);
 


### PR DESCRIPTION
Although the parameter "port" is stored in a variable of type "NSNumber", it may not always be a number. JavaScript is not type-save, so if the socket.open call in Js provides the port as a string, it is also stored as a string inside the plugin. Calling "open" on the socketAdapter however leads an the error message.