### PR TITLE
First close then invoke close event handler

### DIFF
--- a/src/android/src/cz/blocshop/socketsforcordova/SocketAdapterImpl.java
+++ b/src/android/src/cz/blocshop/socketsforcordova/SocketAdapterImpl.java
@@ -76,8 +76,8 @@ public class SocketAdapterImpl implements SocketAdapter {
     
     @Override
     public void close() throws IOException {
-    	this.invokeCloseEventHandler(false);
     	this.socket.close();
+    	this.invokeCloseEventHandler(false);
     }
 
     @Override

--- a/src/ios/SocketsForCordova/Classes/SocketAdapter.m
+++ b/src/ios/SocketsForCordova/Classes/SocketAdapter.m
@@ -266,8 +266,8 @@ int writeTimeoutSeconds = 5.0;
 }
 
 - (void)close {
-    self.closeEventHandler(FALSE);
     [self closeStreams];
+    self.closeEventHandler(FALSE);
 }
 
 - (void)closeStreams {

--- a/src/wp8/src/SocketAdapter.cs
+++ b/src/wp8/src/SocketAdapter.cs
@@ -80,8 +80,8 @@ namespace Blocshop.ScoketsForCordova
 
         public void Close()
         {
-            this.CloseEventHandler(false);
             this.socket.Close();
+            this.CloseEventHandler(false);
         }
 
         private void StartReadTask()


### PR DESCRIPTION
We assume the close event was fired before actually closing the socket because close might throw, leaving the close event to never be called.

However this produces a problem; the socket may not be closed yet when the event is received and handled by web code.

When we receive the close event we start the next connection, which may be to the same destination, but our destination doesn't accept simultaneous connections (so it fails).

I realize we may want to wrap this in a try catch and log/handle the error differently than throwing, but I wasn't sure about what you would expect here, so providing this here for feedback.

Happy to hear from you!